### PR TITLE
撮影画像が上下逆になる件および、オートフォーカスがかからなくなる件の修正　Refs #101861

### DIFF
--- a/src/main/java/com/eaglesakura/android/camera/Camera2ControlManager.java
+++ b/src/main/java/com/eaglesakura/android/camera/Camera2ControlManager.java
@@ -450,8 +450,8 @@ public class Camera2ControlManager extends CameraControlManager {
         CameraCaptureSession session = getSession();
         try {
             if (mPreviewRequest != null) {
-                // AFがかからないことがあるためコメント
-                // startPreCapture(session, mPreviewSurface.getNativeSurface(mPreviewRequest.getPreviewSize()), env);
+                // この処理はおそらく必要ないと思われる
+                startPreCapture(session, mPreviewSurface.getNativeSurface(mPreviewRequest.getPreviewSize()), env);
             }
 
             Holder<CameraException> errorHolder = new Holder<>();
@@ -484,7 +484,8 @@ public class Camera2ControlManager extends CameraControlManager {
             }, mProcessingHandler);
 
             CaptureRequest.Builder builder = newCaptureRequest(env, CameraDevice.TEMPLATE_STILL_CAPTURE);
-            builder.set(CaptureRequest.JPEG_ORIENTATION, getJpegOrientation());
+            // memo: アプリ側でJPEGの回転角を決定するため削除
+            //builder.set(CaptureRequest.JPEG_ORIENTATION, getJpegOrientation());
 
             // Lat/Lng
             if (mPictureShotRequest.hasLocation()) {

--- a/src/main/java/com/eaglesakura/android/camera/Camera2ControlManager.java
+++ b/src/main/java/com/eaglesakura/android/camera/Camera2ControlManager.java
@@ -276,7 +276,12 @@ public class Camera2ControlManager extends CameraControlManager {
             default:
                 break;
         }
-        return (calcRotation + sensorOrientation + 270) % 360;
+        if (mConnectRequest.getCameraType() == CameraType.Back) {
+            return (calcRotation + sensorOrientation + 270) % 360;
+
+        } else {
+            return (sensorOrientation + ContextUtil.getDeviceRotateDegree(mContext) + 360) % 360;
+        }
     }
 
     private CaptureRequest.Builder newCaptureRequest(CameraEnvironmentRequest env, int template) throws CameraAccessException {

--- a/src/main/java/com/eaglesakura/android/camera/Camera2ControlManager.java
+++ b/src/main/java/com/eaglesakura/android/camera/Camera2ControlManager.java
@@ -116,12 +116,12 @@ public class Camera2ControlManager extends CameraControlManager {
      */
     @Override
     public int getCameraSensorOrientation() {
-        if ( mCamera != null && mSpec != null ) {
+        if (mCamera != null && mSpec != null) {
             try {
                 CameraCharacteristics c = mSpec.getCameraManager().getCameraCharacteristics(mCamera.getId());
                 return c.get(CameraCharacteristics.SENSOR_ORIENTATION);
 
-            } catch ( CameraAccessException e ) {
+            } catch (CameraAccessException e) {
                 // 握りつぶす
             }
         }
@@ -484,8 +484,7 @@ public class Camera2ControlManager extends CameraControlManager {
             }, mProcessingHandler);
 
             CaptureRequest.Builder builder = newCaptureRequest(env, CameraDevice.TEMPLATE_STILL_CAPTURE);
-            // memo: アプリ側でJPEGの回転角を決定するため削除
-            //builder.set(CaptureRequest.JPEG_ORIENTATION, getJpegOrientation());
+            builder.set(CaptureRequest.JPEG_ORIENTATION, getJpegOrientation());
 
             // Lat/Lng
             if (mPictureShotRequest.hasLocation()) {

--- a/src/main/java/com/eaglesakura/android/camera/CameraControlManager.java
+++ b/src/main/java/com/eaglesakura/android/camera/CameraControlManager.java
@@ -31,6 +31,11 @@ public abstract class CameraControlManager {
     }
 
     /**
+     * カメラのセンサー角度を取得する
+     */
+    public abstract int getCameraSensorOrientation();
+
+    /**
      * 利用しているAPIを取得する
      */
     @NonNull

--- a/src/main/java/com/eaglesakura/android/camera/LegacyCameraControlManager.java
+++ b/src/main/java/com/eaglesakura/android/camera/LegacyCameraControlManager.java
@@ -46,6 +46,11 @@ public class LegacyCameraControlManager extends CameraControlManager {
         super(context, request);
     }
 
+    @Override
+    public int getCameraSensorOrientation() {
+        return 0;
+    }
+
     @NonNull
     @Override
     public CameraApi getSupportApi() {


### PR DESCRIPTION
オートフォーカスがかからない件の修正
... startPreCaptureをcomment

撮影画像が上下逆になる件の修正
... アプリ側でJPEGの回転角を全て決定できるように、android-camera側でJPEG_ORIENTATIONを設定しないように変更